### PR TITLE
공통 레이아웃 및 폰트 적용

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,45 @@
+/* 
+최상단에 고정해야 CDN으로 폰트가 가져와집니다.
+*/
+@import url('https://cdn.jsdelivr.net/gh/sun-typeface/SUIT/fonts/static/woff2/SUIT.css');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  :root {
+    --layout-max-w: 430px;
+    --layout-min-h: 100dvh;
+  }
+
+  .body-layout {
+    @apply flex min-h-[var(--layout-min-h)] w-screen justify-center overflow-x-hidden overflow-y-scroll;
+  }
+
+  .main-layout {
+    @apply relative w-full max-w-[var(--layout-max-w)] bg-white;
+  }
+}
+
+* {
+  font-family:
+    'SUIT',
+    -apple-system,
+    BlinkMacSystemFont,
+    system-ui,
+    Roboto,
+    'Helvetica Neue',
+    'Segoe UI',
+    'Apple SD Gothic Neo',
+    'Noto Sans KR',
+    'Malgun Gothic',
+    'Apple Color Emoji',
+    'Segoe UI Emoji',
+    'Segoe UI Symbol',
+    sans-serif;
+  user-select: none;
+}
 
 html {
   font-size: 16px;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,9 +9,17 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: PropsWithStrictChildren) {
   return (
+    <Layout>
+      <Providers>{children}</Providers>
+    </Layout>
+  );
+}
+
+function Layout({ children }: PropsWithStrictChildren) {
+  return (
     <html lang="ko">
-      <body>
-        <Providers>{children}</Providers>
+      <body className="body-layout">
+        <main className="main-layout">{children}</main>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,3 @@
 export default function Home() {
-  return <main></main>;
+  return <>Home</>;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #3 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
- max-width: 430px, min-height: 100dvh
- 430px를 분기점으로 잡았습니다.
- SUIT 폰트 전역으로 적용하였습니다. 개인적으로 npm으로 폰트 설치하는 걸 선호하는데 수트 폰트가 npm에는 없네요.  CDN으로 가져오는 방식이라 네트워크 상황에 따라 지연될 수 있는데 추후에 로컬에서 가져오는 방식으로 리펙토링 해보겠습니다.
<img src="https://github.com/ForFunGyeol/frontend/assets/48711263/aa689e60-1a74-46e0-8e29-bcbcf48e5e41" width="500px">


## 💬 리뷰어에게

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
