### PR TITLE
바텀시트 고도화

### DIFF
--- a/src/app/(mood)/waiting/funnels/step1/Step1.tsx
+++ b/src/app/(mood)/waiting/funnels/step1/Step1.tsx
@@ -4,10 +4,10 @@ import MoodForm from './components/MoodForm';
 
 export default function Step1() {
   return (
-    <div className="dark:bg-gray-900 dark:text-white">
+    <>
       <IntroTitle />
       <MoodBoard />
       <MoodForm />
-    </div>
+    </>
   );
 }

--- a/src/app/(mood)/waiting/funnels/step1/components/BodyTypeBottomSheet.tsx
+++ b/src/app/(mood)/waiting/funnels/step1/components/BodyTypeBottomSheet.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import Button from '@/components/common/Button/Button';
-import CloseIcon from '@public/svg/close-24.svg';
 import CheckBox from '@/components/common/CheckBox';
-import useClickAway from '@/hooks/useClickAway';
-import { Fragment } from 'react';
 import { type UseFormReturn, useWatch } from 'react-hook-form';
 import type { MoodContextValue } from '../../../components/MoodContext';
 import BottomSheet from '@/components/common/Modal/BottomSheet';
+import useBottomSheet from '@/hooks/useBottomSheet';
+import { ButtonWrapper } from '@/components/common/Button';
+import Spacing from '@/components/common/Spacing';
 
 const BODY_TYPE_LIST = ['마름', '탄탄 슬림', '보통', '통통', '근육'] as const;
 
@@ -18,41 +18,38 @@ type BodyTypeBottomSheet = {
 };
 
 export default function BodyTypeBottomSheet({ useForm, onClose, isOpen }: BodyTypeBottomSheet) {
+  const { ref, maxBottomSheetContentHeight } = useBottomSheet(() => onClose());
   const { setValue, control } = useForm;
   const bodyType = useWatch({
     control,
     name: 'bodyType',
   });
 
-  const ref = useClickAway<HTMLDivElement>(() => {
-    onClose();
-  });
-
   return (
-    <BottomSheet isOpen={isOpen} ref={ref}>
-      <div className="mb-[57px] flex items-center">
-        <button onClick={onClose}>
-          <CloseIcon />
-        </button>
-        <span className="absolute inset-x-0 text-center font-bold text-gray-900">체형 선택</span>
-      </div>
-      <div className="mb-[57px] ml-1 flex flex-col gap-y-[34px]">
+    <BottomSheet isOpen={isOpen} ref={ref} onClose={onClose} headerTitle="체형 선택">
+      <Spacing size={52} />
+      <div
+        className="flex h-full flex-col gap-y-[34px] overflow-y-scroll"
+        style={{ maxHeight: maxBottomSheetContentHeight }}
+      >
         {BODY_TYPE_LIST.map((value, index) => (
-          <Fragment key={index}>
-            <CheckBox
-              id={`${value}-checkbox`}
-              label={value}
-              isChecked={bodyType === value}
-              onChange={() => {
-                setValue('bodyType', value, {
-                  shouldDirty: true,
-                });
-              }}
-            />
-          </Fragment>
+          <CheckBox
+            key={index}
+            id={`${value}-checkbox`}
+            label={value}
+            isChecked={bodyType === value}
+            onChange={() => {
+              setValue('bodyType', value, {
+                shouldDirty: true,
+              });
+            }}
+          />
         ))}
       </div>
-      <Button onClick={onClose}>확인</Button>
+      <Spacing size={52} />
+      <ButtonWrapper>
+        <Button onClick={onClose}>확인</Button>
+      </ButtonWrapper>
     </BottomSheet>
   );
 }

--- a/src/app/(mood)/waiting/funnels/step1/components/BodyTypeBottomSheet.tsx
+++ b/src/app/(mood)/waiting/funnels/step1/components/BodyTypeBottomSheet.tsx
@@ -29,13 +29,42 @@ export default function BodyTypeBottomSheet({ useForm, onClose, isOpen }: BodyTy
     <BottomSheet isOpen={isOpen} ref={ref} onClose={onClose} headerTitle="체형 선택">
       <Spacing size={52} />
       <div
-        className="flex h-full flex-col gap-y-[34px] overflow-y-scroll"
+        className="flex h-full snap-y snap-mandatory flex-col gap-y-[34px] overflow-y-scroll"
         style={{ maxHeight: maxBottomSheetContentHeight }}
       >
         {BODY_TYPE_LIST.map((value, index) => (
           <CheckBox
             key={index}
             id={`${value}-checkbox`}
+            className="snap-center"
+            label={value}
+            isChecked={bodyType === value}
+            onChange={() => {
+              setValue('bodyType', value, {
+                shouldDirty: true,
+              });
+            }}
+          />
+        ))}
+        {BODY_TYPE_LIST.map((value, index) => (
+          <CheckBox
+            key={index}
+            id={`${value}-checkbox`}
+            className="snap-center"
+            label={value}
+            isChecked={bodyType === value}
+            onChange={() => {
+              setValue('bodyType', value, {
+                shouldDirty: true,
+              });
+            }}
+          />
+        ))}
+        {BODY_TYPE_LIST.map((value, index) => (
+          <CheckBox
+            key={index}
+            id={`${value}-checkbox`}
+            className="snap-center"
             label={value}
             isChecked={bodyType === value}
             onChange={() => {

--- a/src/app/(mood)/waiting/funnels/step1/components/MoodForm.tsx
+++ b/src/app/(mood)/waiting/funnels/step1/components/MoodForm.tsx
@@ -56,7 +56,7 @@ export default function MoodForm() {
           required={!errors.nickname?.message && !!nickname}
           error={errors.nickname?.message}
         />
-        <p className="mt-2 text-xs text-[#0071FF]">매칭이 되었을 때만 상대방에게 보여줘요</p>
+        <p className="mt-2 text-xs text-[#1E6DD1]">매칭이 되었을 때만 상대방에게 보여줘요</p>
         <Spacing size={28} />
         <BirthdaySection />
         <BodyTypeSection />

--- a/src/app/(mood)/waiting/funnels/step1/components/RegionSection.tsx
+++ b/src/app/(mood)/waiting/funnels/step1/components/RegionSection.tsx
@@ -29,7 +29,9 @@ export default function RegionSection() {
       </div>
       <div className="flex gap-x-2">
         <button
-          className={cn(`h-[52px] w-full rounded-lg bg-gray-50 dark:bg-gray-800`)}
+          className={cn(
+            `h-[52px] w-full rounded-lg border border-gray-200 bg-gray-50 dark:border-gray-200 dark:bg-gray-800`,
+          )}
           onClick={() => open(({ exit }) => <PostCodePopup onClose={exit} useForm={useForm} />)}
         >
           <span className="mx-4 flex items-center justify-between gap-x-2 text-sm text-gray-700 dark:text-gray-300">

--- a/src/app/(mood)/waiting/funnels/step1/components/WaitingHeader.tsx
+++ b/src/app/(mood)/waiting/funnels/step1/components/WaitingHeader.tsx
@@ -36,9 +36,9 @@ const convertStepToText = (step: string) => {
   switch (step) {
     case '1':
       return '자기소개 작성';
-    case '2':
-      return '나의 가치관 작성';
     case '3':
+      return '나의 가치관 작성';
+    case '4':
       return '프로필 사진';
   }
 };

--- a/src/app/(mood)/waiting/page.tsx
+++ b/src/app/(mood)/waiting/page.tsx
@@ -10,7 +10,9 @@ export default function Waiting() {
 
   return (
     <>
-      <WaitingHeader isDark={currentStep === '1'} currentStep={currentStep} />
+      {!(currentStep === '2' || currentStep === '5') && (
+        <WaitingHeader isDark={currentStep === '1'} currentStep={currentStep} />
+      )}
       <Funnel>
         <Funnel.step name="1">
           <div className="dark-mode absolute top-0 w-full pt-[57px]">
@@ -19,6 +21,12 @@ export default function Waiting() {
         </Funnel.step>
         <Funnel.step name="2">
           <div>Step 2 | 상세 프로필 작성할까요?</div>
+          <ButtonWrapper>
+            <Button onClick={nextStep}>작성하러가기</Button>
+          </ButtonWrapper>
+        </Funnel.step>
+        <Funnel.step name="3">
+          <div>Step 3 </div>
           <ButtonWrapper>
             <Button onClick={nextStep}>작성하러가기</Button>
           </ButtonWrapper>

--- a/src/app/(mood)/waiting/page.tsx
+++ b/src/app/(mood)/waiting/page.tsx
@@ -13,7 +13,9 @@ export default function Waiting() {
       <WaitingHeader isDark={currentStep === '1'} currentStep={currentStep} />
       <Funnel>
         <Funnel.step name="1">
-          <Step1 />
+          <div className="dark-mode absolute top-0 w-full pt-[57px]">
+            <Step1 />
+          </div>
         </Funnel.step>
         <Funnel.step name="2">
           <div>Step 2 | 상세 프로필 작성할까요?</div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,6 +27,10 @@
   .main-layout {
     @apply relative h-full w-full max-w-[var(--layout-max-w)] overflow-x-hidden overflow-y-scroll bg-white text-gray-900;
   }
+
+  .dark-mode {
+    @apply dark:bg-gray-900 dark:text-white;
+  }
 }
 
 * {

--- a/src/assets/RightArrow.tsx
+++ b/src/assets/RightArrow.tsx
@@ -9,7 +9,7 @@ export default function RightArrow(props: React.SVGProps<SVGSVGElement>) {
       className="text-gray-600 dark:text-gray-400"
       {...props}
     >
-      <path d="M6 12L10 8L6 4" stroke="#595959" strokeLinejoin="round" />
+      <path d="M6 12L10 8L6 4" stroke="currentColor" strokeLinejoin="round" />
     </svg>
   );
 }

--- a/src/components/common/CheckBox.tsx
+++ b/src/components/common/CheckBox.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { cn } from '@/utils';
 import CheckBoxActiveIcon from '@public/svg/checkbox-active-16.svg';
 import CheckBoxInActiveIcon from '@public/svg/checkbox-inactive-16.svg';
 
@@ -8,13 +9,21 @@ type CheckBoxProps = React.InputHTMLAttributes<HTMLInputElement> & {
   isChecked?: boolean;
 };
 
-export default function CheckBox({ id, label, isChecked, onChange, ...rest }: CheckBoxProps) {
+export default function CheckBox({
+  id,
+  label,
+  isChecked,
+  onChange,
+  className,
+  ...rest
+}: CheckBoxProps) {
+  console.log(className);
   return (
     <label htmlFor={id} className="flex gap-x-2">
       <input
         id={id}
         type="checkbox"
-        className="appearance-none"
+        className={cn('appearance-none', className)}
         checked={isChecked}
         onChange={onChange}
         {...rest}

--- a/src/constants/bottomSheet.ts
+++ b/src/constants/bottomSheet.ts
@@ -1,0 +1,10 @@
+export const MIN_Y = 60 as const;
+
+export const HEADER_HEIGHT = 80 as const;
+
+export const BOTTOM_HEIGHT = 170 as const;
+
+/**
+ * 바텀시트 헤더 + 하단 버튼 영역 + 바텀 시트 상단 여백
+ */
+export const MAX_BOTTOM_SHEET_CONTENT = HEADER_HEIGHT + BOTTOM_HEIGHT + MIN_Y;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,2 +1,3 @@
 export * from './motions';
 export * from './keywords';
+export * from './bottomSheet';

--- a/src/hooks/useBottomSheet.ts
+++ b/src/hooks/useBottomSheet.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import { useClickAway } from '.';
+import { MAX_BOTTOM_SHEET_CONTENT, MIN_Y } from '@/constants';
+
+const useBottomSheet = (handler: VoidFunction) => {
+  const [deviceHeight, setDeviceHeight] = useState(0);
+
+  const ref = useClickAway<HTMLDivElement>(() => {
+    handler();
+  });
+
+  useEffect(() => {
+    setDeviceHeight(window.innerHeight);
+  }, []);
+
+  return {
+    maxScrollHeight: deviceHeight - 150,
+    maxBottomSheetHeight: deviceHeight - MIN_Y,
+    maxBottomSheetContentHeight: deviceHeight - MAX_BOTTOM_SHEET_CONTENT,
+    ref,
+  };
+};
+
+export default useBottomSheet;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #33 
## 📝 작업 내용

- 헤더 영역을 드래그 할 경우 바텀시트가 올라가거나 내려가도록 구현했습니다. 일정 높이 이상 올리거나 내릴 경우 바텀시트가 닫힙니다.
- 높이를 컨텐츠 요소로 잡도록 유동적으로 설정하고, 컨텐츠 요소가 길어질 경우 스크롤이 가능하도록 기능을 추가했습니다.

![화면 기록 2024-02-06 오후 10 48 38](https://github.com/ForFunGyeol/frontend/assets/48711263/d13fee22-54bc-4aca-8459-faa5dd47f3ed)
- 디자인 변경사항을 반영했습니다.
<img width="415" alt="image" src="https://github.com/ForFunGyeol/frontend/assets/48711263/1d3e98e2-7df4-4a63-b16f-e38af93edcd1">


## 💬 리뷰어에게

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
