### PR TITLE
Step1 유효성 강화 및 키워드 터치 스와이프 구현

### DIFF
--- a/src/app/(mood)/waiting/funnels/step1/components/BirthdaySection.tsx
+++ b/src/app/(mood)/waiting/funnels/step1/components/BirthdaySection.tsx
@@ -5,9 +5,15 @@ import CheckIcon from '@public/svg/check-16.svg';
 import { useMoodContext } from '../../../components/MoodContext';
 import { useWatch } from 'react-hook-form';
 import Spacing from '@/components/common/Spacing';
+import WaringIcon from '@public/svg/warning-16.svg';
 
 export default function BirthdaySection() {
-  const { setValue, control, register } = useMoodContext();
+  const {
+    setValue,
+    control,
+    register,
+    formState: { errors },
+  } = useMoodContext();
 
   const birthday = useWatch({
     control,
@@ -24,12 +30,18 @@ export default function BirthdaySection() {
         <label htmlFor="birthday-input" className="text-sm text-gray-600 dark:text-gray-400">
           생년월일
         </label>
-        {birthday && gender && <CheckIcon />}
+        {!errors.birthday?.message && gender && birthday && <CheckIcon />}
       </div>
-      <div className="flex gap-x-2">
+      <div className="relative flex gap-x-2">
         <input
           {...register('birthday', {
             required: true,
+            pattern: {
+              value: /^\d{4}\.\d{2}\.\d{2}$/,
+              message: 'YYYY.MM.DD 형식으로 입력해주세요.',
+            },
+            validate: (value) =>
+              Number(value.slice(0, 4)) < 2006 || '2005년생 이후는 가입이 불가능합니다.',
           })}
           id="birthday-input"
           placeholder="예시) 2024.01.25"
@@ -37,6 +49,12 @@ export default function BirthdaySection() {
             `h-[52px] w-full flex-[2] rounded-lg border-[1px] border-gray-100 bg-transparent px-4 text-sm outline-none placeholder:text-base focus:border-primary-400 dark:border-gray-800 dark:text-white placeholder:dark:text-gray-700`,
           )}
         />
+        {errors.birthday?.message && (
+          <p className="absolute top-full mt-2 inline-flex items-center gap-x-1 text-xs text-error">
+            <WaringIcon />
+            {errors.birthday?.message}
+          </p>
+        )}
         <div className="flex flex-1 gap-x-2">
           <button
             onClick={() =>

--- a/src/app/(mood)/waiting/funnels/step1/components/BodyTypeSection.tsx
+++ b/src/app/(mood)/waiting/funnels/step1/components/BodyTypeSection.tsx
@@ -9,7 +9,11 @@ import CheckIcon from '@public/svg/check-16.svg';
 
 export default function BodyTypeSection() {
   const useForm = useMoodContext();
-  const { control, register } = useForm;
+  const {
+    control,
+    register,
+    formState: { errors },
+  } = useForm;
   const height = useWatch({
     control,
     name: 'height',
@@ -25,12 +29,17 @@ export default function BodyTypeSection() {
         <label htmlFor="bodytype-input" className="text-sm text-gray-600 dark:text-gray-400">
           키 / 체형
         </label>
-        {height && bodyType && <CheckIcon />}
+        {height && bodyType && !errors.height?.message && <CheckIcon />}
       </div>
       <div className="relative flex gap-x-2">
         <div className="relative w-full flex-[2_2_0%]">
           <input
-            {...register('height')}
+            {...register('height', {
+              required: true,
+              minLength: 3,
+              maxLength: 3,
+              pattern: /^[0-9]*$/,
+            })}
             id="bodytype-input"
             placeholder="예) 170"
             className={cn(

--- a/src/app/(mood)/waiting/funnels/step1/components/MyKeywordPopup.tsx
+++ b/src/app/(mood)/waiting/funnels/step1/components/MyKeywordPopup.tsx
@@ -39,12 +39,12 @@ export default function MyKeywordPopup({ useForm, onClose, isOpen }: MyKeywordPo
         <p className="mb-5 mt-2 text-xs text-gray-500">5개까지 선택 가능</p>
         <Keywords useForm={useForm} />
         <Spacing size={86} />
-        <ul className="fixed inset-x-0 bottom-[112px] mx-auto flex h-20 w-full max-w-[430px] items-center gap-x-2 overflow-scroll border-t border-t-gray-100 bg-gray-50 pl-5">
+        <ul className="fixed inset-x-0 bottom-[112px] mx-auto flex h-20 w-full max-w-[430px] snap-x snap-mandatory items-center gap-x-2 overflow-scroll border-t border-t-gray-100 bg-gray-50 px-5">
           {keywords.map((keyword, index) => (
             <li
               key={index}
               onClick={() => handleRemoveKeyword(keyword)}
-              className="flex h-10 w-fit cursor-pointer items-center justify-center gap-x-1 whitespace-nowrap rounded-[48px] border border-gray-100 bg-white pl-4 pr-3 text-sm text-gray-900"
+              className="flex h-10 w-fit cursor-pointer snap-center items-center justify-center gap-x-1 whitespace-nowrap rounded-[48px] border border-gray-100 bg-white pl-4 pr-3 text-sm text-gray-900"
             >
               {keyword}
               <DeleteIcon />


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #36 

## 📝 작업 내용

- scroll-snap을 통해 부드러운 모션으로 터치 스와이프를 구현했습니다.
- 생일, 키 항목에 validation을 추가했습니다.

![화면 기록 2024-02-07 오후 3 12 53](https://github.com/ForFunGyeol/frontend/assets/48711263/edf0b5ff-13cf-456a-b5b9-9716b4da1613)


## 💬 리뷰어에게

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
