### PR TITLE
배포 플로우 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: Frontend CD
 
 on:
   push:
-    branches: [dev]
+    branches: [dev, main]
 
 jobs:
   build:
@@ -23,6 +23,6 @@ jobs:
           destination-repository-name: flowing-deployment
           user-email: ${{ secrets.OFFICIAL_ACCOUNT_EMAIL }}
           commit-message: ${{ github.event.commits[0].message }}
-          target-branch: dev
+          target-branch: ${{ github.ref_name }}
       - name: Test get variable exported by push-to-another-repository
         run: echo $DESTINATION_CLONED_DIRECTORY


### PR DESCRIPTION
기존에는 여기 레포지토리의 dev가 푸시가 발생되면 https://github.com/thyeone/flowing-deployment 의 dev 브랜치로 코드 push가 발생합니다.

그래서 수동으로 dev를 main으로 병합하기 위해 PR을 생성해서 수동으로 머지해주어야 했습니다. 이 문제로 인해 지금까지의 코드 수정이 반영이 안되고 있었습니다;; 또한, 직접 머지해줄 때마다 컨플릭트가 발생해서 main으로 머지할 수 없었습니다.

여기의 main 브랜치와 원격 레포지토리의 main 코드를 일치시키기 위해 yml 파일을 수정했습니다. 이 방법이 잘 안된다면 main 브랜치 하나로 운영할 예정입니다.